### PR TITLE
Remove /var/spool/cwl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ notifications:
 
 before_install:
   - docker build -t quay.io/pancancer/pcawg-bwa-mem-workflow:2.6.8_1.2 .
-  - pip2.7 install --user setuptools==24.0.3
 
 install: 
-  - pip2.7 install --user cwl-runner cwltool==1.0.20160712154127 schema-salad==1.14.20160708181155 avro==1.8.1
+  - pip2.7 install --user -r requirements.txt
 
 script: 
   - cwltool --non-strict --print-pre Dockstore.cwl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+setuptools==40.8.0
+cwl-runner
+cwltool==1.0.20181217162649
+schema-salad==3.0.20181206233650
+avro==1.8.2
+ruamel.yaml==0.15.77
+requests==2.21.0

--- a/scripts/run_seqware_workflow.py
+++ b/scripts/run_seqware_workflow.py
@@ -137,16 +137,17 @@ def collect_args():
 
 
 def link_references(args):
+    work_dir = os.environ['PWD']
     execute("export TMPDIR=/tmp")
-    execute("export HOME=/var/spool/cwl")
+    execute("export HOME=%s" % work_dir)
     execute("whoami")
     execute("gosu root chown -R seqware /data")
     execute("gosu root chown -R seqware /home/seqware")
     execute("gosu root chmod -R a+wrx /home/seqware");
-    execute("gosu root mkdir -p /var/spool/cwl/.seqware");
-    execute("gosu root chown -R seqware /var/spool/cwl/");
-    execute("gosu root cp /home/seqware/.seqware/settings /var/spool/cwl/.seqware");
-    execute("gosu root chmod a+wrx /var/spool/cwl/.seqware/settings");
+    execute("gosu root mkdir -p %s/.seqware" % work_dir);
+    execute("gosu root chown -R seqware %s" % work_dir);
+    execute("gosu root cp /home/seqware/.seqware/settings %s/.seqware" % work_dir);
+    execute("gosu root chmod a+wrx %s/.seqware/settings" % work_dir);
     execute("perl -pi -e 's/wrench.res/seqwaremaven/g' /home/seqware/bin/seqware");
     dest = os.path.join(workflow_bundle_dir,
                         workflow_bundle,

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,7 +5,9 @@ set -o pipefail
 set -x
 
 gosu root chmod a+wrx /tmp
-gosu root chmod a+wrx /var/spool/cwl
+WORK_DIR=$HOME
+cd $HOME
 gosu seqware bash -c "$*"
 #allow cwltool to pick up the results created by seqware
-gosu root chmod -R a+wrx  /var/spool/cwl
+gosu root chmod -R a+wrx $WORK_DIR
+


### PR DESCRIPTION
Removing /var/spool/cwl .  Seems to successfully runs when I tested it.  Need someone else to confirm

This is so that the new cwltool version can successfully run this tool.  The requirements.txt file was gotten from Dockstore 1.6.0.  

I can remove
```
ruamel.yaml==0.15.77
requests==2.21.0
```
for simplicity if needed.